### PR TITLE
Bugfix: configure_rstudio() crashes when installing dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,5 +22,3 @@ Imports:
   tidyr (>= 0.8.2),
   tidyverse (>= 1.2.1),
   xaringan (>= 0.8)
-Remotes:
-

--- a/config_rstudio_server.R
+++ b/config_rstudio_server.R
@@ -1,8 +1,8 @@
 #!/usr/bin/env Rscript
 
-configure_rstudio <- function(threads = 4) {
+configure_rstudio <- function(threads = 2) {
   user_info <- get_user_info()
-  install_usethis_and_remotes_pkgs(threads = threads)
+  install_usethis_and_remotes_pkgs()
   # configure_renviron()
   configure_git(user_info$user_name, user_info$user_email)
   install_course_dependencies(threads = threads)
@@ -93,11 +93,10 @@ configure_git <- function(user_name, user_email) {
   )
 }
 
-install_usethis_and_remotes_pkgs <- function(threads) {
+install_usethis_and_remotes_pkgs <- function() {
   install.packages(
     pkgs = c("usethis", "remotes"),
-    repos = "https://cran.rstudio.com",
-    Ncpus = threads
+    repos = "https://cran.rstudio.com"
   )
 }
 


### PR DESCRIPTION
* Problem fixed: DESCRIPTION file had "Remotes:" but no entries after it.
  Removed "Remotes:" since it is not needed.
* Some threading issues where script would get ahead of itself, only use threads
  input for final step, installing dependencies listed in the DESCRIPTION file.